### PR TITLE
Add phase-2 segment reconstruction and calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ git cms-merge-topic oglez:Phase2_DTAB7Unpacker_v9.1
 git cms-merge-topic battibass:Phase2_DTRecoAndCalib
 git cms-merge-topic -u pozzobon:DTHough_NP_20191004_106X_noL1T # MTT-CHT emulator
 git cms-merge-topic -u dtp2-tpg-am:v1.4_AM_106X # AM emulator
-git clone https://github.com/battibass/DTNtuples.git DTDPGAnalysis/DTNtuples -b add_muon_reco 
+git clone https://github.com/battibass/DTNtuples.git DTDPGAnalysis/DTNtuples
 scramv1 b -j 5
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ cd CMSSW_10_6_5_patch1/src/
 cmsenv
 git cms-merge-topic oglez:Phase2_DTAB7Unpacker_v9.1
 git cms-merge-topic battibass:phase-2_DT_reco_fix
-git cms-merge-topic -u pozzobon:DTHough_NP_20191004_106X_noL1T# MTT-CHT emulator
+git cms-merge-topic -u pozzobon:DTHough_NP_20191004_106X_noL1T # MTT-CHT emulator
 git cms-merge-topic -u dtp2-tpg-am:v1.4_AM_106X # AM emulator
-git clone https://github.com/battibass/DTNtuples.git DTDPGAnalysis/DTNtuples
+git clone https://github.com/battibass/DTNtuples.git DTDPGAnalysis/DTNtuples -b add_muon_reco 
 scramv1 b -j 5
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ In the present days this code is evolving fast, hence the installation recipe ma
 cmsrel CMSSW_10_6_5_patch1
 cd CMSSW_10_6_5_patch1/src/
 cmsenv
-git cms-merge-topic oglez:Phase2_DTAB7Unpacker_v9. 1
-git cms-merge-topic battibass:phase-2_reco_fix
+git cms-merge-topic oglez:Phase2_DTAB7Unpacker_v9.1
+git cms-merge-topic battibass:phase-2_DT_reco_fix
 git cms-merge-topic -u pozzobon:DTHough_NP_20191004_106X_noL1T# MTT-CHT emulator
 git cms-merge-topic -u dtp2-tpg-am:v1.4_AM_106X # AM emulator
 git clone https://github.com/battibass/DTNtuples.git DTDPGAnalysis/DTNtuples

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ cmsrel CMSSW_10_6_5_patch1
 cd CMSSW_10_6_5_patch1/src/
 cmsenv
 git cms-merge-topic oglez:Phase2_DTAB7Unpacker_v9.1
-git cms-merge-topic battibass:phase-2_DT_reco_fix
+git cms-merge-topic battibass:Phase2_DTRecoAndCalib
 git cms-merge-topic -u pozzobon:DTHough_NP_20191004_106X_noL1T # MTT-CHT emulator
 git cms-merge-topic -u dtp2-tpg-am:v1.4_AM_106X # AM emulator
 git clone https://github.com/battibass/DTNtuples.git DTDPGAnalysis/DTNtuples -b add_muon_reco 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ In the present days this code is evolving fast, hence the installation recipe ma
 
 ### Installation:
 ```
-cmsrel CMSSW_10_6_0
-cd CMSSW_10_6_0/src/
+cmsrel CMSSW_10_6_5_patch1
+cd CMSSW_10_6_5_patch1/src/
 cmsenv
-git cms-merge-topic oglez:Phase2_CMSSW_10_6_0_pre4_Summer2019 # phase-2 unpacker
-git cms-merge-topic -u pozzobon:DTHough_NP_20190619_106X_noL1T # MTT-CHT emulator
-git cms-merge-topic -u dtp2-tpg-am:AM_106X_dev # AM emulator
+git cms-merge-topic oglez:Phase2_DTAB7Unpacker_v9. 1
+git cms-merge-topic battibass:phase-2_reco_fix
+git cms-merge-topic -u pozzobon:DTHough_NP_20191004_106X_noL1T# MTT-CHT emulator
+git cms-merge-topic -u dtp2-tpg-am:v1.4_AM_106X # AM emulator
 git clone https://github.com/battibass/DTNtuples.git DTDPGAnalysis/DTNtuples
 scramv1 b -j 5
 ```

--- a/python/customiseDtNtuples_cff.py
+++ b/python/customiseDtNtuples_cff.py
@@ -7,7 +7,7 @@ def customiseForRunningOnMC(process, pathName) :
         print "[customiseForRunningOnMC]: updating ntuple input tags"
 
         process.dtNtupleProducer.genPartTag = "prunedGenParticles"
-        # process.dtNtupleProducer.puInfoTag = "addPileupInfo"
+        process.dtNtupleProducer.puInfoTag = "addPileupInfo"
 
         process.dtNtupleProducer.lumiScalerTag = "none"
 

--- a/python/customiseDtPhase2Reco_cff.py
+++ b/python/customiseDtPhase2Reco_cff.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+def customiseForPhase2Reco(process, pathName, tTrigFile, t0File) :
+
+    process.dt1DRecHitsPh2 = process.dt1DRecHits.clone()
+    process.dt1DRecHitsPh2.dtDigiLabel = cms.InputTag("dtAB7unpacker")
+
+    process.dt4DSegmentsPh2 = process.dt4DSegments.clone()
+    process.dt4DSegmentsPh2.recHits1DLabel = cms.InputTag("dt1DRecHitsPh2")
+
+    process.dt4DSegmentsT0SegPh2 = process.dt4DSegmentsT0Seg.clone()
+    process.dt4DSegmentsT0SegPh2.recHits4DLabel = cms.InputTag("dt4DSegmentsPh2")
+
+    process.dtlocalrecoT0SegPh2 = cms.Sequence( process.dt1DRecHitsPh2
+                                                + process.dt4DSegmentsPh2
+                                                + process.dt4DSegmentsT0SegPh2 )
+
+
+
+    if tTrigFile != '' :
+        process.dt1DRecHitsPh2.recAlgoConfig.tTrigModeConfig.tTrigLabel  = cms.string('cosmics_ph2')
+        process.dt4DSegmentsPh2.Reco4DAlgoConfig.Reco2DAlgoConfig.recAlgoConfig.tTrigModeConfig.tTrigLabel  = cms.string('cosmics_ph2')
+        process.dt4DSegmentsPh2.Reco4DAlgoConfig.recAlgoConfig.tTrigModeConfig.tTrigLabel  = cms.string('cosmics_ph2')
+        process.dt4DSegmentsT0SegPh2.recAlgoConfig.tTrigModeConfig.tTrigLabel  = cms.string('cosmics_ph2')
+
+    if t0File != '' :
+        process.dt1DRecHitsPh2.recAlgoConfig.tTrigModeConfig.t0Label  = cms.string('ph2')
+        process.dt4DSegmentsPh2.Reco4DAlgoConfig.Reco2DAlgoConfig.recAlgoConfig.tTrigModeConfig.t0Label  = cms.string('ph2')
+        process.dt4DSegmentsPh2.Reco4DAlgoConfig.recAlgoConfig.tTrigModeConfig.t0Label  = cms.string('ph2')
+        process.dt4DSegmentsT0SegPh2.recAlgoConfig.tTrigModeConfig.t0Label  = cms.string('ph2')
+
+    if hasattr(process,"dtNtupleProducer") and hasattr(process,pathName) :
+
+        print "[customiseForPhase2Reco]: including phase-2 local reco in ntuples"
+
+        process.dtNtupleProducer.ph2DtSegmentTag = cms.untracked.InputTag("dt4DSegmentsPh2")
+
+        getattr(process,pathName).replace(process.dtNtupleProducer,
+                                          process.dtlocalrecoT0SegPh2
+                                          + process.dtNtupleProducer)
+
+    return process

--- a/test/dtDpgNtuples_slicetest_cfg.py
+++ b/test/dtDpgNtuples_slicetest_cfg.py
@@ -48,13 +48,26 @@ options.register('tTrigFile',
                  '', #default value
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.string,
-                 "File with customised DT tTrigs, used only if non ''")
+                 "File with customised DT legacy tTrigs, used only if non ''")
 
 options.register('t0File',
                  '', #default value
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.string,
-                 "File with customised DT t0is, used only if non ''")
+                 "File with customised DT legacy t0is, used only if non ''")
+
+options.register('tTrigFilePh2',
+                 '', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "File with customised DT phase-2 tTrigs, used only if non ''")
+
+options.register('t0FilePh2',
+                 '', #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.string,
+                 "File with customised DT phase-2 t0is, used only if non ''")
+
 
 options.register('vDriftFile',
                  '', #default value
@@ -84,9 +97,11 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condD
 
 process.GlobalTag.globaltag = cms.string(options.globalTag)
 
-if options.tTrigFile  != '' or \
-   options.vDriftFile != '' or \
-   options.t0File != '' :
+if options.tTrigFile    != '' or \
+   options.t0File       != '' or \
+   options.tTrigFilePh2 != '' or \
+   options.t0FilePh2    != '' or \
+   options.vDriftFile   != '' :
     process.GlobalTag.toGet = cms.VPSet()
 
 if options.tTrigFile != '' :
@@ -97,20 +112,35 @@ if options.tTrigFile != '' :
                                         )
                                )
 
-if options.vDriftFile != '' :
-    process.GlobalTag.toGet.append(cms.PSet(record = cms.string("DTMtimeRcd"),
-                                            tag = cms.string("vDrift"),
-                                            connect = cms.string("sqlite_file:" + options.vDriftFile)
-                                        )
-                                   )
-
 if options.t0File != '' :
     process.GlobalTag.toGet.append(cms.PSet(record = cms.string("DTT0Rcd"),
                                             tag = cms.string("t0"),
                                             connect = cms.string("sqlite_file:" + options.t0File)
                                         )
                                    )
-    
+
+if options.tTrigFilePh2 != '' :
+    process.GlobalTag.toGet.append(cms.PSet(record = cms.string("DTTtrigRcd"),
+                                            tag = cms.string("ttrig"),
+                                            connect = cms.string("sqlite_file:" + options.tTrigFilePh2),
+                                            label = cms.untracked.string("cosmics_ph2")
+                                        )
+                               )
+
+if options.t0FilePh2 != '' :
+    process.GlobalTag.toGet.append(cms.PSet(record = cms.string("DTT0Rcd"),
+                                            tag = cms.string("t0"),
+                                            connect = cms.string("sqlite_file:" + options.t0FilePh2),
+                                            label = cms.untracked.string("ph2")
+                                        )
+                                   )
+
+if options.vDriftFile != '' :
+    process.GlobalTag.toGet.append(cms.PSet(record = cms.string("DTMtimeRcd"),
+                                            tag = cms.string("vDrift"),
+                                            connect = cms.string("sqlite_file:" + options.vDriftFile)
+                                        )
+                                   )
 
 process.source = cms.Source("PoolSource",
                             
@@ -181,3 +211,7 @@ process.p = cms.Path(process.muonDTDigis
                      + process.bmtfDigis
                      + process.dtlocalrecoT0Seg
                      + process.dtNtupleProducer)
+
+if options.tTrigFilePh2 != '' and options.t0FilePh2 != '' :
+    from DTDPGAnalysis.DTNtuples.customiseDtPhase2Reco_cff import customiseForPhase2Reco
+    process = customiseForPhase2Reco(process,"p", options.tTrigFilePh2, options.t0FilePh2)

--- a/test/dtDpgNtuples_slicetest_cfg.py
+++ b/test/dtDpgNtuples_slicetest_cfg.py
@@ -21,7 +21,7 @@ options.register('nEvents',
                  "Maximum number of processed events")
 
 options.register('runNumber',
-                 '329806', #default value
+                 '333369', #default value
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.int,
                  "Run number to be looked for in either 'inputFolderCentral' or 'inputFolderDT' folders")
@@ -57,13 +57,13 @@ options.register('t0File',
                  "File with customised DT legacy t0is, used only if non ''")
 
 options.register('tTrigFilePh2',
-                 '', #default value
+                 '/eos/cms/store/group/dpg_dt/comm_dt/commissioning_2019_data/calib/ttrig_phase2_Run333369.db', #default value
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.string,
                  "File with customised DT phase-2 tTrigs, used only if non ''")
 
 options.register('t0FilePh2',
-                 '', #default value
+                 '/eos/cms/store/group/dpg_dt/comm_dt/commissioning_2019_data/calib/t0_phase2_Run333364.db', #default value
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.string,
                  "File with customised DT phase-2 t0is, used only if non ''")
@@ -75,6 +75,12 @@ options.register('vDriftFile',
                  VarParsing.VarParsing.varType.string,
                  "File with customised DT vDrifts, used only if non ''")
 
+options.register('runOnDat',
+                 False, #default value
+                 VarParsing.VarParsing.multiplicity.singleton,
+                 VarParsing.VarParsing.varType.bool,
+                 "If set to True switches source from 'PoolSource' to 'NewEventStreamFileReader'")
+
 options.register('ntupleName',
                  '', #default value
                  VarParsing.VarParsing.multiplicity.singleton,
@@ -83,6 +89,11 @@ options.register('ntupleName',
 
 
 options.parseArguments()
+
+if options.runOnDat :
+    inputSourceType = "NewEventStreamFileReader"
+else:
+    inputSourceType = "PoolSource"
 
 process = cms.Process("DTNTUPLES",eras.Run2_2018)
 
@@ -142,11 +153,9 @@ if options.vDriftFile != '' :
                                         )
                                    )
 
-process.source = cms.Source("PoolSource",
+process.source = cms.Source(inputSourceType,
                             
-        fileNames = cms.untracked.vstring(),
-        secondaryFileNames = cms.untracked.vstring()
-
+        fileNames = cms.untracked.vstring()
 )
 
 if options.inputFile != '' :
@@ -157,8 +166,10 @@ if options.inputFile != '' :
 else :
 
     runStr = str(options.runNumber).zfill(9)
-    runFolder = options.inputFolderCentral + "/" + runStr[0:3] + "/" + runStr[3:6] + "/" + runStr[6:] + "/00000"
-
+    runFolder = options.inputFolderCentral + "/" + runStr[0:3] + "/" + runStr[3:6] + "/" + runStr[6:] 
+    if not options.runOnDat:
+        runFolder = runFolder + "/00000"
+    
     print "[dtDpgNtuples_slicetest_cfg.py]: looking for files under:\n\t\t\t" + runFolder
     
     if os.path.exists(runFolder) :


### PR DESCRIPTION
This PR:
Updates the deployment to use:
- unpacker: oglez:Phase2_DTAB7Unpacker_v9.1
- additional reco/calibration code: battibass:Phase2_DTRecoAndCalib
- MTT-CHT emulator: pozzobon:DTHough_NP_20191004_106X_noL1T 
- AM emulator: dtp2-tpg-am:v1.4_AM_106X

Includes phase-2 segment reconstruction related cff/cfg

Switches to: CMSSW_10_6_5_patch1

Fills properly PU information in simulation workflows