### PR TITLE
Modifying phi, phib ranges and bits; adding segment phi branches

### DIFF
--- a/src/DTNtupleSegmentFiller.cc
+++ b/src/DTNtupleSegmentFiller.cc
@@ -89,6 +89,9 @@ void DTNtupleSegmentFiller::initialize()
   m_tree->Branch((m_label + "_posLoc_x_midPlane").c_str(), &m_seg4D_posLoc_x_midPlane);
 
   m_tree->Branch((m_label + "_posGlb_phi").c_str(), &m_seg4D_posGlb_phi);
+  m_tree->Branch((m_label + "_posGlb_phi_midPlane").c_str(), &m_seg4D_posGlb_phi_midPlane);
+  m_tree->Branch((m_label + "_posGlb_phi_SL1").c_str(), &m_seg4D_posGlb_phi_SL1);
+  m_tree->Branch((m_label + "_posGlb_phi_SL3").c_str(), &m_seg4D_posGlb_phi_SL3);
   m_tree->Branch((m_label + "_posGlb_eta").c_str(), &m_seg4D_posGlb_eta);
 
   m_tree->Branch((m_label + "_dirGlb_phi").c_str(), &m_seg4D_dirGlb_phi);
@@ -155,6 +158,9 @@ void DTNtupleSegmentFiller::clear()
   m_seg4D_posLoc_x_midPlane.clear(); 
 
   m_seg4D_posGlb_phi.clear();
+  m_seg4D_posGlb_phi_midPlane.clear();
+  m_seg4D_posGlb_phi_SL1.clear();
+  m_seg4D_posGlb_phi_SL3.clear();
   m_seg4D_posGlb_eta.clear();
   m_seg4D_dirGlb_phi.clear();
   m_seg4D_dirGlb_eta.clear();
@@ -244,11 +250,16 @@ void DTNtupleSegmentFiller::fill(const edm::Event & ev)
 	      m_seg4D_dirLoc_x.push_back(dir.x());
 	      m_seg4D_dirLoc_y.push_back(dir.y());
 	      m_seg4D_dirLoc_z.push_back(dir.z());
-	      
+
 	      float xPosLocSL[2] = { DTNtupleBaseFiller::DEFAULT_DOUBLE_VAL,
-				     DTNtupleBaseFiller::DEFAULT_DOUBLE_VAL };
+	                             DTNtupleBaseFiller::DEFAULT_DOUBLE_VAL };
+	      float zPosLocSL[2] = { DTNtupleBaseFiller::DEFAULT_DOUBLE_VAL,
+	                             DTNtupleBaseFiller::DEFAULT_DOUBLE_VAL };
+	      float phiGlobSL[2] = { DTNtupleBaseFiller::DEFAULT_DOUBLE_VAL,
+	                             DTNtupleBaseFiller::DEFAULT_DOUBLE_VAL };
 	      bool hasPptSL[2] = { false, false };
 	      float xPosLocMidPlane = DTNtupleBaseFiller::DEFAULT_DOUBLE_VAL;
+	      float zPosLocMidPlane = DTNtupleBaseFiller::DEFAULT_DOUBLE_VAL;
 
 	      if (hasPhi || hasZed)
 		{
@@ -288,14 +299,17 @@ void DTNtupleSegmentFiller::fill(const edm::Event & ev)
 			  if (hasPptSL[iSL])
 			    {
 			      GlobalPoint segExrapolationToSL(pptSL.second);
+	                      phiGlobSL[iSL] = segExrapolationToSL.phi();
 			      LocalPoint  segPosAtSLChamber = chamb->toLocal(segExrapolationToSL);
-			      xPosLocSL[iSL] = segPosAtSLChamber.x();
+	                      xPosLocSL[iSL] = segPosAtSLChamber.x();
+	                      zPosLocSL[iSL] = segPosAtSLChamber.z();
 			    }
 			}
 		      
 		      if (hasPptSL[0] && hasPptSL[1])
 			{
 			  xPosLocMidPlane = (xPosLocSL[0] + xPosLocSL[1]) * 0.5;
+	                  zPosLocMidPlane = (zPosLocSL[0] + zPosLocSL[1]) * 0.5;
 			}
 		    }
  
@@ -361,9 +375,13 @@ void DTNtupleSegmentFiller::fill(const edm::Event & ev)
 
 	      const GeomDet * geomDet = m_config->m_trackingGeometry->idToDet(segment4D->geographicalId());
 	      auto posGlb = geomDet->toGlobal(pos);
+	      auto midPlanePosGlb = geomDet->toGlobal(LocalPoint(xPosLocMidPlane, 0, zPosLocMidPlane));
 	      auto dirGlb = geomDet->toGlobal(dir); // CB do values have sense?
-	      
+
 	      m_seg4D_posGlb_phi.push_back(posGlb.phi());
+	      m_seg4D_posGlb_phi_SL1.push_back(phiGlobSL[0]);
+	      m_seg4D_posGlb_phi_SL3.push_back(phiGlobSL[1]);
+	      m_seg4D_posGlb_phi_midPlane.push_back(midPlanePosGlb.phi());
 	      m_seg4D_posGlb_eta.push_back(posGlb.eta());
 
 	      m_seg4D_dirGlb_phi.push_back(dirGlb.phi());

--- a/src/DTNtupleSegmentFiller.h
+++ b/src/DTNtupleSegmentFiller.h
@@ -97,6 +97,9 @@ class DTNtupleSegmentFiller : public DTNtupleBaseFiller
   std::vector<float> m_seg4D_posLoc_x_midPlane; // position x at SL1 - SL3 mid plane in local coordinates (float in cm)
 
   std::vector<float> m_seg4D_posGlb_phi; // position phi in global coordinates (float in radians [-pi:pi])
+  std::vector<float> m_seg4D_posGlb_phi_midPlane; // position phi at SL1 - SL3 mid plane in global coordinates (float in radians [-pi:pi])
+  std::vector<float> m_seg4D_posGlb_phi_SL1; // position phi at SL1 in global coordinates (float in radians [-pi:pi])
+  std::vector<float> m_seg4D_posGlb_phi_SL3; // position phi at SL3 in global coordinates (float in radians [-pi:pi])
   std::vector<float> m_seg4D_posGlb_eta; // position eta in global coordinates (float)
   std::vector<float> m_seg4D_dirGlb_phi; // position phi in global coordinates (float in radians [-pi:pi])
   std::vector<float> m_seg4D_dirGlb_eta; // position eta in global coordinates (float)

--- a/src/DTTrigGeomUtils.cc
+++ b/src/DTTrigGeomUtils.cc
@@ -30,7 +30,6 @@
 
 using namespace edm;
 using namespace std;
-using namespace cmsdt;
 
 
 DTTrigGeomUtils::DTTrigGeomUtils(ESHandle<DTGeometry> muonGeom, bool dirInDeg) : muonGeom_(muonGeom) 
@@ -293,11 +292,11 @@ float DTTrigGeomUtils::trigPosAM(const L1Phase2MuDTPhDigi* trig)
   double deltaphi = phicenter-phin;
 
   double zRF=0;
-  if (quality == LOWLOWQ || quality == HIGHLOWQ || quality == HIGHHIGHQ) zRF=zcn_[st-1];
+  if (quality == cmsdt::LOWLOWQ || quality == cmsdt::HIGHLOWQ || quality == cmsdt::HIGHHIGHQ) zRF=zcn_[st-1];
   else if (sl==1) zRF=zsl1_[st-1];
   else if (sl==3) zRF=zsl3_[st-1];
 
-  double x = (tan(phi/PHIRES_CONV))*(r*cos(deltaphi) - zRF)-r*sin(deltaphi); //zRF is in local coordinates -> z invreases approching to vertex
+  double x = (tan(phi/cmsdt::PHIRES_CONV))*(r*cos(deltaphi) - zRF)-r*sin(deltaphi); //zRF is in local coordinates -> z invreases approching to vertex
 
   if (hasPosRF(wh,sec)){ x = -x; } // change sign in case of positive wheels
 
@@ -312,7 +311,7 @@ float DTTrigGeomUtils::trigDirAM(const L1Phase2MuDTPhDigi* trig)
   int phi  = trig->phi();
   int phib = trig->phiBend();
 
-  float dir = (phib/PHIBRES_CONV+phi/PHIRES_CONV)*radToDeg_;
+  float dir = (phib/cmsdt::PHIBRES_CONV+phi/cmsdt::PHIRES_CONV)*radToDeg_;
   
   // change sign in case of negative wheels
   if (!hasPosRF(wh,sec)) { dir = -dir; }

--- a/src/DTTrigGeomUtils.cc
+++ b/src/DTTrigGeomUtils.cc
@@ -14,6 +14,9 @@
 #include "DataFormats/L1DTTrackFinder/interface/L1MuDTChambPhDigi.h"
 #include "DataFormats/L1DTTrackFinder/interface/L1Phase2MuDTPhDigi.h"
 
+// DT AM Emulator constants
+#include "L1Trigger/DTTriggerPhase2/interface/constants.h"
+
 // Geometry & Segment
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
@@ -27,6 +30,7 @@
 
 using namespace edm;
 using namespace std;
+using namespace cmsdt;
 
 
 DTTrigGeomUtils::DTTrigGeomUtils(ESHandle<DTGeometry> muonGeom, bool dirInDeg) : muonGeom_(muonGeom) 
@@ -289,11 +293,11 @@ float DTTrigGeomUtils::trigPosAM(const L1Phase2MuDTPhDigi* trig)
   double deltaphi = phicenter-phin;
 
   double zRF=0;
-  if (quality>=6 && quality !=7) zRF=zcn_[st-1];
-  if ((quality <6 || quality==7) && sl==1) zRF=zsl1_[st-1];
-  if ((quality <6 || quality==7) && sl==3) zRF=zsl3_[st-1];
+  if (quality == LOWLOWQ || quality == HIGHLOWQ || quality == HIGHHIGHQ) zRF=zcn_[st-1];
+  else if (sl==1) zRF=zsl1_[st-1];
+  else if (sl==3) zRF=zsl3_[st-1];
 
-  double x = (tan(phi*0.8/65536.))*(r*cos(deltaphi) - zRF)-r*sin(deltaphi); //zRF is in local coordinates -> z invreases approching to vertex
+  double x = (tan(phi/PHIRES_CONV))*(r*cos(deltaphi) - zRF)-r*sin(deltaphi); //zRF is in local coordinates -> z invreases approching to vertex
 
   if (hasPosRF(wh,sec)){ x = -x; } // change sign in case of positive wheels
 
@@ -308,7 +312,7 @@ float DTTrigGeomUtils::trigDirAM(const L1Phase2MuDTPhDigi* trig)
   int phi  = trig->phi();
   int phib = trig->phiBend();
 
-  float dir = (phib*1.4/2048.+phi*0.8/65536.)*radToDeg_;
+  float dir = (phib/PHIBRES_CONV+phi/PHIRES_CONV)*radToDeg_;
   
   // change sign in case of negative wheels
   if (!hasPosRF(wh,sec)) { dir = -dir; }


### PR DESCRIPTION
Ciao @battibass , this PR includes the information we agreed in past meetings to add to the DTNtuples: 
- Added new branches with the segment phi extrapolated to each SL and the midPlane between the SLs (to be able to compare in a proper way with the TPs)
- Modified the phi and phib conversion factors. Instead of modifying the actual values, I've left them dependent on the ones used in the emulator version that it's been considered. Just as a reminder, the unpacker does not include yet the modification in the conversion factors, so if you use the latest emulator version (which should be already merged in central CMSSW) you will see a difference between HW and AM primitives.
- The DTTrigGeomUtils::trigPosAM function has a dependency on the quality considered (qualities 6, 8 and 9 are considered ascorrelated and the others as SL primitives). As we changed the quality definition, this had to be corrected. As in the previous point, I have left them dependent on the quality code used in the emulator. In any case, if in the future we add information about theta in the quality code, the function will probably have to be modified again.